### PR TITLE
Remove unused OpenCV calibration dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,7 @@ endif()
 if (NOT WIN32 AND NOT APPLE)
     set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc")
 endif()
-set(OpenCV_LIBS opencv_core opencv_imgproc opencv_highgui opencv_calib3d)
+set(OpenCV_LIBS opencv_core opencv_imgproc opencv_highgui)
 
 set(GSPLAT_LIBS gsplat_cpu)
 if((GPU_RUNTIME STREQUAL "CUDA") OR (GPU_RUNTIME STREQUAL "HIP"))

--- a/input_data.hpp
+++ b/input_data.hpp
@@ -5,7 +5,6 @@
 #include <string>
 #include <fstream>
 #include <unordered_map>
-#include <opencv2/calib3d.hpp>
 #include <torch/torch.h>
 
 enum CameraType { Perspective };


### PR DESCRIPTION
This addresses an OpenCV 5 build compatibility issue discovered while building OpenSplat with the current Homebrew OpenCV package.